### PR TITLE
use substitute-command-keys

### DIFF
--- a/unkillable-scratch.el
+++ b/unkillable-scratch.el
@@ -102,7 +102,7 @@ The following values are recognized:
   "Reset the contents of the *scratch* buffer to `initial-scratch-message'."
   (with-current-buffer "*scratch*"
     (delete-region (point-min) (point-max))
-    (insert (or initial-scratch-message ""))))
+    (insert (or (substitute-command-keys initial-scratch-message) ""))))
 
 (defun unkillable-scratch-buffer ()
   "Apply the `unkillable-scratch-behavior' to the buffer passed to

--- a/unkillable-scratch.el
+++ b/unkillable-scratch.el
@@ -33,7 +33,7 @@
 ;; being killed.  Any buffer matching a regexp in the list
 ;; `unkillable-buffers' will not be killed.
 
-;; Only one bufer is in `unkillable-buffers' by default: the *scratch*
+;; Only one buffer is in `unkillable-buffers' by default: the *scratch*
 ;; buffer.
 
 ;; The *scratch* buffer is considered specially; in the event of a call to
@@ -56,7 +56,7 @@
 
 ;; - unkillable-scratch-really-kill
 ;;     actually kill the selected buffer at point.  If this buffer was
-;;     the last matching buffer to the regexp(s) keeping him from being
+;;     the last matching buffer to the regexp(s) keeping it from being
 ;;     killed, remove said regexp(s) from `unkillable-buffers'.
 ;;
 


### PR DESCRIPTION
This causes the scratch buffer, when repopulated with the default text, to include the `C-x C-f` text instead of the `\[find-file]` escape:

```
;; This buffer is for text that is not saved, and for Lisp evaluation.
;; To create a file, visit it with C-x C-f and enter text in its buffer.
```